### PR TITLE
Prevent exception from Raygun client middleware

### DIFF
--- a/src/WebApp/Platform/Raygun/RaygunClientProvider.cs
+++ b/src/WebApp/Platform/Raygun/RaygunClientProvider.cs
@@ -13,7 +13,10 @@ public class RaygunClientProvider : DefaultRaygunAspNetCoreClientProvider
 
         client.SendingMessage += (_, args) =>
         {
-            args.Message.Details.Tags ??= new List<string>();
+            args.Message.Details.Tags = args.Message.Details.Tags is null
+                ? new List<string>()
+                : args.Message.Details.Tags.ToList();
+
             args.Message.Details.Tags.Add(Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
         };
 


### PR DESCRIPTION
Convert Raygun message `Tags` property to generic `List<T>` before adding a tag, in case it was initialized as a fixed-size array.

fixes #52 